### PR TITLE
Updated php dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         }
     ],
     "require": {
+		"php": "^8.0",
         "guzzlehttp/guzzle": "^7.4",
         "spatie/laravel-data": "^1.2"
     },


### PR DESCRIPTION
Requires PHP 8 because of if clauses using pipes